### PR TITLE
fix: Display and count past due appointments correctly

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -45,7 +45,7 @@ export default function DashboardPage() {
     appointments,
     loading: appointmentsLoading,
     getTodayAppointments,
-    getUpcomingAppointments,
+    getAllRemindersSorted,
   } = useAppointments()
   const router = useRouter()
   const [isLoggingOut, setIsLoggingOut] = useState(false)
@@ -130,7 +130,7 @@ export default function DashboardPage() {
 
   const todayAppointments = getTodayAppointments()
   const next7DaysAppointments = getNext7DaysAppointments()
-  const upcomingReminders = getUpcomingAppointments(3)
+  const upcomingReminders = getAllRemindersSorted()
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-orange-50">


### PR DESCRIPTION
## Overview
This PR addresses two issues in the appointments view:

- Corrects the "Past Due" summary card count to accurately reflect appointments with "programada" or "recordatorio" status.
- Adds the missing UI section to render the list of pastDueAppointments.
- This ensures all relevant past due appointments are visible and correctly tallied.